### PR TITLE
fix(4.0.1): state not cleared on redirect to page with same stack size

### DIFF
--- a/ngx-state-stack-workspace/package.json
+++ b/ngx-state-stack-workspace/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser-dynamic": "~10.0.0",
     "@angular/router": "~10.0.0",
     "core-js": "^3.6.5",
-    "rxjs": "~6.5.5",
+    "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
   },
@@ -41,7 +41,7 @@
     "@types/jasmine": "~3.5.10",
     "@types/jasminewd2": "~2.0.8",
     "@types/node": "^12.11.1",
-    "codelyzer": "^5.2.2",
+    "codelyzer": "^5.2.0",
     "husky": "~4.2.5",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/ngx-state-stack-workspace/projects/ngx-state-stack/package.json
+++ b/ngx-state-stack-workspace/projects/ngx-state-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-state-stack",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Angular state management in form of a stack, for example when using Breadcrumbs",
   "author": {

--- a/ngx-state-stack-workspace/projects/ngx-state-stack/src/lib/states.service.spec.ts
+++ b/ngx-state-stack-workspace/projects/ngx-state-stack/src/lib/states.service.spec.ts
@@ -74,6 +74,24 @@ describe('StatesService', () => {
     );
   });
 
+  it('should clear the initialized state, if the new state is at the same level the current state, but has a different root path', () => {
+    const routePath = '/my/route';
+    const state = { routePath: routePath } as AppState;
+
+    const service: StatesService = TestBed.inject(StatesService);
+    service.initRoute(routePath);
+
+    service.cache(state);
+
+    service.clearStateUntilRoute(routePath, '/other/route');
+
+    expect(() => service.restore(routePath)).toThrow(
+      new Error(
+        '[StatesService] - State not found. Please check if you have set up the StateGuard correctly.'
+      )
+    );
+  });
+
   it('should prevail the first state, if the new state is above the current state, but a lower one than before', () => {
     const routePathOne = '/one';
     const routePathTwo = routePathOne + '/two';

--- a/ngx-state-stack-workspace/projects/ngx-state-stack/src/lib/states.service.ts
+++ b/ngx-state-stack-workspace/projects/ngx-state-stack/src/lib/states.service.ts
@@ -89,11 +89,7 @@ export class StatesService {
     }
 
     // Reached current route - stop cleaning up
-    if (
-      newRoutePath.split('/').length ===
-        states[0].routePath.split('/').length &&
-      !isForwardNavigation
-    ) {
+    if (states[0].routePath === newRoutePath && !isForwardNavigation) {
       return states;
     }
 

--- a/ngx-state-stack-workspace/yarn.lock
+++ b/ngx-state-stack-workspace/yarn.lock
@@ -2906,7 +2906,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codelyzer@^5.2.2:
+codelyzer@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-5.2.2.tgz#d0530a455784e6bea0b6d7e97166c73c30a5347f"
   integrity sha512-jB4FZ1Sx7kZhvZVdf+N2BaKTdrrNZOL0Bj10RRfrhHrb3zEvXjJvvq298JPMJAiyiCS/v4zs1QlGU0ip7xGqeA==
@@ -8740,7 +8740,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6.5.5, rxjs@^6.5.3, rxjs@~6.5.5:
+rxjs@6.5.5, rxjs@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
@@ -8751,6 +8751,13 @@ rxjs@^6.5.0:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@~6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Example-Routing:

Route 1: /my/first
Route 2: /my/second
Route 3: /my/first

=> State was not cleared between these navigations.
State of Route 1 should have been cleared when navigating to Route 2.